### PR TITLE
Implementation of getTransducerValues

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -1,5 +1,5 @@
 {
-"db": "mongodb://database/openchirp_test",
+"db": "mongodb://mongodb/openchirp_test",
 "mqtt": {
    	"broker": "tls://iot.andrew.cmu.edu",
    	"port":"1883",

--- a/config/development.json
+++ b/config/development.json
@@ -1,5 +1,5 @@
 {
-"db": "mongodb://localhost/openchirp_test",
+"db": "mongodb://database/openchirp_test",
 "mqtt": {
    	"broker": "tls://iot.andrew.cmu.edu",
    	"port":"1883",

--- a/config/development.json
+++ b/config/development.json
@@ -1,10 +1,14 @@
 {
-"db": "mongodb://mongodb/openchirp_test",
+"db": "mongodb://localhost/openchirp_test",
 "mqtt": {
    	"broker": "tls://iot.andrew.cmu.edu",
    	"port":"1883",
    	"user":"openchirp_rest",
    	"pass":""
+ },
+ "influxdb": {
+ 	"host": "128.237.216.67",
+ 	"port": "8086"
  },
  "enable_auth" : false, 
  "auth_google":{

--- a/config/development.json
+++ b/config/development.json
@@ -8,8 +8,8 @@
  },
  "enable_auth" : false, 
  "auth_google":{
-    "clientID": "",
-    "clientSecret": "",
+    "clientID": "clientID",
+    "clientSecret": "clientSecret",
     "callbackURL": "http://iot.andrew.cmu.edu:10010/auth/google/callback"
  }
 }

--- a/src/middleware/resource_managers/transducer_manager.js
+++ b/src/middleware/resource_managers/transducer_manager.js
@@ -83,7 +83,7 @@ exports.getDeviceTransducer = function(req, callback ){
     
     measurement = req.device+req.params._transducerId.toLowerCase();
 	var result = new Object();
-    result.message = "Done";
+    result.message = measurement;
     return callback(null, result);	
 };
 

--- a/src/middleware/resource_managers/transducer_manager.js
+++ b/src/middleware/resource_managers/transducer_manager.js
@@ -30,6 +30,7 @@ var getTransducerLastValue = function(device, callback){
 			"db" : "openchirp",
 			"q" : query
 		};
+
         request({url : url, qs : props}, function(err, response, body) {
   			if(err) { console.log(err);  }
 			 var data  = JSON.parse(body);
@@ -91,14 +92,14 @@ exports.getDeviceTransducer = function(req, callback ){
 			"q" : query
 	};
 
-    var result = request({url : url, qs : props}, function(err, response, body) {
+    request({url : url, qs : props}, function(err, response, body) {
   			//if(err) { console.log(err);  }
 			//var data  = JSON.parse(body);
 
 			var result = new Object();
     		result.message = measurement;
-			
-			return result;	
+
+			callback(null, result);	
 		}); 
 
 	//var result = new Object();

--- a/src/middleware/resource_managers/transducer_manager.js
+++ b/src/middleware/resource_managers/transducer_manager.js
@@ -82,8 +82,8 @@ exports.publish = function(device, transducerId, message, callback){
 exports.getDeviceTransducer = function(req, callback ){
     
     measurement = req.device+req.params._transducerId.toLowerCase();
-    
-    result.message = "measurement";
+	var result = new Object();
+    result.message = "Done";
     return callback(null, result);	
 };
 

--- a/src/middleware/resource_managers/transducer_manager.js
+++ b/src/middleware/resource_managers/transducer_manager.js
@@ -81,25 +81,6 @@ exports.publish = function(device, transducerId, message, callback){
     mqttClient.publish(topic, message, callback);
 };
 
-String.prototype.formatUnicorn = String.prototype.formatUnicorn ||
-function () {
-    "use strict";
-    var str = this.toString();
-    if (arguments.length) {
-        var t = typeof arguments[0];
-        var key;
-        var args = ("string" === t || "number" === t) ?
-            Array.prototype.slice.call(arguments)
-            : arguments[0];
-
-        for (key in args) {
-            str = str.replace(new RegExp("\\{" + key + "\\}", "gi"), args[key]);
-        }
-    }
-
-    return str;
-};
-
 exports.getDeviceTransducer = function(req, res){
   	/* influxdb url */
     var influxdb_url = "http://"+ nconf.get('influxdb:host') + ":" + nconf.get("influxdb:port") + "/query";

--- a/src/middleware/resource_managers/transducer_manager.js
+++ b/src/middleware/resource_managers/transducer_manager.js
@@ -92,10 +92,13 @@ exports.getDeviceTransducer = function(req, callback ){
 	};
 
     var result = request({url : url, qs : props}, function(err, response, body) {
-  			if(err) { console.log(err);  }
-			var data  = JSON.parse(body);
+  			//if(err) { console.log(err);  }
+			//var data  = JSON.parse(body);
+
+			var result = new Object();
+    		result.message = measurement;
 			
-			return body;	
+			return result;	
 		}); 
 
 	//var result = new Object();

--- a/src/middleware/resource_managers/transducer_manager.js
+++ b/src/middleware/resource_managers/transducer_manager.js
@@ -81,7 +81,7 @@ exports.publish = function(device, transducerId, message, callback){
 
 exports.getDeviceTransducer = function(req, callback ){
     
-    measurement = req.device._id+'_'req.params.name.toLowerCase();
+    measurement = req.device._id+'_'+req.params.name.toLowerCase();
 
 	var url = "http://"+ nconf.get('influxdb:host') + ":" + nconf.get("influxdb:port") +"/query" ;
 
@@ -90,7 +90,7 @@ exports.getDeviceTransducer = function(req, callback ){
 			"db" : "openchirp",
 			"q" : query
 	};
-	
+
     request({url : url, qs : props}, function(err, response, body) {
   			if(err) { console.log(err);  }
 			var data  = JSON.parse(body);

--- a/src/middleware/resource_managers/transducer_manager.js
+++ b/src/middleware/resource_managers/transducer_manager.js
@@ -79,15 +79,30 @@ exports.publish = function(device, transducerId, message, callback){
     mqttClient.publish(topic, message, callback);
 };
 
+exports.getDeviceTransducer = function(req, callback ){
+    
+    measurement = req.device+req.params._transducerId name.toLowerCase();
+    
+    result.message = "measurement";
+    return callback(null, result);	
+};
+
 exports.deleteDeviceTransducer = function(req, callback){	
 	var tdcId = req.params._transducerId;
-	var commands = req.device.commands;
-	if(commands){
-		for (var i = 0; i < commands.length; i++) {
-			if(commands[i].transducer_id == tdcId)
-				req.device.commands.id(commands[i]._id).remove();
-		}
+	var commands = req.device.commands;	
+	var cmdsToDelete = [];
+	
+	if(commands){		
+		commands.forEach(function(cmd) {
+			if ( String(cmd.transducer_id) === String(tdcId)){
+				cmdsToDelete.push(cmd._id);
+			}
+		});
 	}
+	cmdsToDelete.forEach(function(cid){		
+		req.device.commands.id(cid).remove();
+	});
+	
 	req.device.transducers.id(tdcId).remove();
 	req.device.save( function(err) {
 		if(err) { return callback(err); }

--- a/src/middleware/resource_managers/transducer_manager.js
+++ b/src/middleware/resource_managers/transducer_manager.js
@@ -91,16 +91,15 @@ exports.getDeviceTransducer = function(req, callback ){
 			"q" : query
 	};
 
-    request({url : url, qs : props}, function(err, response, body) {
+    var result = request({url : url, qs : props}, function(err, response, body) {
   			if(err) { console.log(err);  }
 			var data  = JSON.parse(body);
 			
-			return callback(null, body);	
-		});
-	};    
+			return body;	
+		}); 
 
-	var result = new Object();
-    result.message = measurement;
+	//var result = new Object();
+    //result.message = measurement;
     return callback(null, result);	
 };
 

--- a/src/middleware/resource_managers/transducer_manager.js
+++ b/src/middleware/resource_managers/transducer_manager.js
@@ -81,7 +81,24 @@ exports.publish = function(device, transducerId, message, callback){
 
 exports.getDeviceTransducer = function(req, callback ){
     
-    measurement = req.device+req.params._transducerId.toLowerCase();
+    measurement = req.device._id+'_'req.params.name.toLowerCase();
+
+	var url = "http://"+ nconf.get('influxdb:host') + ":" + nconf.get("influxdb:port") +"/query" ;
+
+	var query = "select \"value\" from \"59160549f8e6b6058dd1d4e0_Temperature\"";
+	var props = {
+			"db" : "openchirp",
+			"q" : query
+	};
+	
+    request({url : url, qs : props}, function(err, response, body) {
+  			if(err) { console.log(err);  }
+			var data  = JSON.parse(body);
+			
+			return callback(null, body);	
+		});
+	};    
+
 	var result = new Object();
     result.message = measurement;
     return callback(null, result);	

--- a/src/middleware/resource_managers/transducer_manager.js
+++ b/src/middleware/resource_managers/transducer_manager.js
@@ -99,7 +99,7 @@ exports.getDeviceTransducer = function(req, callback ){
 			var result = new Object();
     		result.message = measurement;
 
-			callback(null, result);	
+			//callback(null, result);	
 		}); 
 
 	//var result = new Object();

--- a/src/middleware/resource_managers/transducer_manager.js
+++ b/src/middleware/resource_managers/transducer_manager.js
@@ -91,7 +91,7 @@ exports.getDeviceTransducer = function(req, callback ){
 			"db" : "openchirp",
 			"q" : query
 	};
-
+/*
     request({url : url, qs : props}, function(err, response, body) {
   			//if(err) { console.log(err);  }
 			//var data  = JSON.parse(body);
@@ -101,9 +101,9 @@ exports.getDeviceTransducer = function(req, callback ){
 
 			//callback(null, result);	
 		}); 
-
-	//var result = new Object();
-    //result.message = measurement;
+*/
+	var result = new Object();
+    result.message = measurement;
     return callback(null, result);	
 };
 

--- a/src/middleware/resource_managers/transducer_manager.js
+++ b/src/middleware/resource_managers/transducer_manager.js
@@ -81,7 +81,7 @@ exports.publish = function(device, transducerId, message, callback){
 
 exports.getDeviceTransducer = function(req, callback ){
     
-    measurement = req.device+req.params._transducerId name.toLowerCase();
+    measurement = req.device+req.params._transducerId.toLowerCase();
     
     result.message = "measurement";
     return callback(null, result);	

--- a/src/routes/device_router.js
+++ b/src/routes/device_router.js
@@ -109,6 +109,14 @@ router.post('/:_id/transducer/:_transducerId', function(req, res, next ){
     })
 });
 
+/* Get device transducer values */
+router.post('/:_id/transducer/:_transducerId', function(req, res, next ){
+    transducerManager.getDeviceTransducer(req, function(err, result){
+        if(err) { return next(err); }
+        return res.json(result);
+    })
+});
+
 /* Delete transducer */
 router.delete('/:_id/transducer/:_transducerId', function(req, res, next ){
     transducerManager.deleteDeviceTransducer(req, function(err, result){

--- a/src/routes/device_router.js
+++ b/src/routes/device_router.js
@@ -110,7 +110,7 @@ router.post('/:_id/transducer/:_transducerId', function(req, res, next ){
 });
 
 /* Get device transducer values */
-router.post('/:_id/transducer/:_transducerId', function(req, res, next ){
+router.get('/:_id/transducer/:_transducerId', function(req, res, next ){
     transducerManager.getDeviceTransducer(req, function(err, result){
         if(err) { return next(err); }
         return res.json(result);

--- a/src/routes/device_router.js
+++ b/src/routes/device_router.js
@@ -111,10 +111,8 @@ router.post('/:_id/transducer/:_transducerId', function(req, res, next ){
 
 /* Get device transducer values */
 router.get('/:_id/transducer/:_transducerId', function(req, res, next ){
-    transducerManager.getDeviceTransducer(req, function(err, result){
-        if(err) { return next(err); }
-        return res.json(result);
-    })
+	/* getDeviceTransducer will directly pipe the incoming response from influxdb to the browser (so no callback) */
+    transducerManager.getDeviceTransducer(req, res); 
 });
 
 /* Delete transducer */


### PR DESCRIPTION
# Getting Values from a Transducer

Performing an HTTP GET to a transducer resource will return the values stored in the database in ascending time order. By default, results are returned in a chunked stream (chunks have a size of 10,000 points) as a single response. 

### Example

- Returns all values in a chunked stream (chunks have a size of 10,000 points), ordered by ascending time order:
`curl -G "http://openchirp.andrew.cmu.edu:10010/api/device/<deviceID>/transducer/<transducerID>"`

# Specifying Query Start and End Times

It is possible to define start and end times using the **STIME** and **ETIME** query string parameters. The time specifications are according to InfluxDB. Bellow you can find some examples of possible time specifications. 

### Examples

- Return values from the last week: 
`curl -G "http://openchirp.andrew.cmu.edu:10010/api/device/<deviceID>/transducer/<transducerID>" --data-urlencode “stime=now() - 1w"`
>About the time specification above: you can use simular time specifications using ‘d’ (days), ‘h’ (hours), ‘m’ (minutes), ’s’ (seconds), ‘ms’ (milliseconds) and ‘u’ (microseconds)
> the spaces between the ‘-‘ operator are important)

- Return values from one week ago until yesterday: 
`curl -G "http://openchirp.andrew.cmu.edu:10010/api/device/<deviceID>/transducer/<transducerID>" --data-urlencode “stime=now() - 1w" --data-urlencode “etime=now() - 1d"`

- Return values between August 18, 2015 23:00:01.232000000 and September 19, 2015 00:00:00:
`curl -G "http://openchirp.andrew.cmu.edu:10010/api/device/<deviceID>/transducer/<transducerID>" --data-urlencode “stime=2015-08-18 23:00:01.232000000" --data-urlencode “etime=2015-09-19"`

>Please check [InfluxDB’s documentation section on Time syntax in Queries](https://docs.influxdata.com/influxdb/v0.9/query_language/data_exploration/#time-syntax-in-queries) for details.

# Specifying Query Limit and Paginating Queries

You can set a limit to the number of points returned using the **LIMIT** query string parameter, which can have a maximum value of 10,000 (**LIMIT**=0 is equal to **LIMIT**=10000). When you do so, results are returned in a single (non-chunked) response. 

The parameter **PAGE** can be used to paginate thought the results, where each page has a size defined by the **LIMIT** argument or 10,000 if no **LIMIT** argument is given.

### Examples

- Return the first (results are in ascending time order) 5000 values:
`curl -G "http://openchirp.andrew.cmu.edu:10010/api/device/<deviceID>/transducer/<transducerID>" --data-urlencode "limit=5000"`

- Return the values in the positions 5000 to 10000 :
`curl -G "http://openchirp.andrew.cmu.edu:10010/api/device/<deviceID>/transducer/<transducerID>" --data-urlencode "limit=5000" --data-urlencode “page=2"`

- Return the values in the positions 10000 to 20000 (implicit LIMIT=10000):
`curl -G "http://openchirp.andrew.cmu.edu:10010/api/device/<deviceID>/transducer/<transducerID>" --data-urlencode "page=2"`

# Specifying CSV or JSON Output

The default output format is JSON. It is possible to specify the output format using the **Content-Type** HTTP header, where:
1. 'text/csv' or  'application/csv' specifies CSV output
2. any other content type will produce JSON output (default)

### Example

- Returns all values in CSV format (in a chunked stream):
`curl -G "http://openchirp.andrew.cmu.edu:10010/api/device/<deviceID>/transducer/<transducerID>" -H "Content-Type:application/csv"`

# Mixing Query Parameters

Remember that you can combine the above parameters...

### Example

- Return the first 5000 values from a week ago:
`curl -G "http://openchirp.andrew.cmu.edu:10010/api/device/<deviceID>/transducer/<transducerID>" --data-urlencode "limit=5000" --data-urlencode “stime=now() - 1w"`
