### PR TITLE
Filter service config from device info

### DIFF
--- a/src/middleware/accesscontrol/service_authorizer.js
+++ b/src/middleware/accesscontrol/service_authorizer.js
@@ -10,24 +10,29 @@ exports.checkPostAccess = function(req, res, next){
 	}
 }
 
-exports.checkWriteAccess = function(req, res, next){
-	var isAdmin = utils.isAdmin(req.user);
-    if(isAdmin){
-        return next();
+exports.isAuthorized = function(req) {
+    if(utils.isAdmin(req.user)){
+        return true;
     }
-	if(String(req.user._id) === String(req.service.owner._id)){
+    if(String(req.user._id) === String(req.service.owner._id)){
+        return true;
+    }
+    // If the user is service's own token, allow access
+    if(req.user.username){
+        if(req.user.username === String(req.service._id)){
+            return true;
+        }
+    }
+    return false;
+};
+
+exports.checkWriteAccess = function(req, res, next){
+	if (exports.isAuthorized(req)) {
 		return next();
+   } else {
+        return next(forbidden_error);
 	}
-	
-	// If the user is service's own token, allow access
-	if(req.user.username){
-		if(req.user.username === String(req.service._id)){
-			return next();
-		}
-	}
-	
-	return next(forbidden_error);
-	
-}
+};
+
 
 module.exports = exports;

--- a/src/middleware/resource_managers/device_manager.js
+++ b/src/middleware/resource_managers/device_manager.js
@@ -173,6 +173,7 @@ exports.getDevicesByOwner = function(req, callback) {
     if(req.query && req.query.name ){
         var name = req.query.name;
     }
+    // This currently does not perform a search on name, as it's limited by userid...
     if(name){
         Device.find({"owner" : userId, $text: { $search: name }}).exec(callback);
     }else{

--- a/src/middleware/resource_managers/location_manager.js
+++ b/src/middleware/resource_managers/location_manager.js
@@ -191,8 +191,7 @@ exports.getAllDevices = function(location_id, callback){
 };
 
 exports.getDevices = function(req, callback){
-    
-    Device.find({ location_id : req.params._id }).select('name pubsub location_id').exec(callback);    
+    Device.find({ location_id : req.params._id }).select('name pubsub location_id').exec(callback);
 };
 
 exports.getLocationsByOwner = function(req, callback) {


### PR DESCRIPTION
ACLs are respected for viewing linked_service configs on devices.
New `/device/<id>/service` and `/device/<id>/service/<serviceid>` GET
routes for specific information, following other device info
components. The latter route has special case exception for
service tokens.