### PR TITLE
Add transducer search route

### DIFF
--- a/cheatsheet.md
+++ b/cheatsheet.md
@@ -93,6 +93,9 @@
         - PUT - Update access to user or group
         - DELETE - Remove access to user or group
 
+* `/search/transducer?q=<query>`
+    - GET - Search by transducer name. 
+    (Optional: search by comma separated list of names) 
 
 ## `/devicetemplate`
 - TODO

--- a/src/middleware/resource_managers/transducer_manager.js
+++ b/src/middleware/resource_managers/transducer_manager.js
@@ -17,9 +17,24 @@ exports.getAllDeviceTransducers = function(req, callback ){
 	Device.findById(deviceId).exec(function(err, result){
 		if(err) { return callback(err); } 
 		getTransducerLastValue(result, callback);
-		
 	})
 };
+
+exports.getTransducerDevices = function(query, callback) {
+    let searchStrings = query.split(',').map(item => item.trim());
+    if (!searchStrings.length) { return callback(null, {}); }
+    let searchParams = [];
+    for (let i = 0; i < searchStrings.length; i++) {
+        searchParams.push({ $elemMatch: {name: searchStrings[i]} });
+	}
+    Device.find({transducers: {$all: searchParams}})
+	.select("name transducers")
+	.exec(function (err, result) {
+        if (err) { return callback(err); }
+        return callback(null, result);
+    })
+};
+
 
 var getTransducerLastValue = function(device, callback){
 	var transducers  = device.transducers;

--- a/src/routes/device_router.js
+++ b/src/routes/device_router.js
@@ -97,6 +97,21 @@ router.delete('/:_id', deviceAuthorizer.checkWriteAccess, function(req, res, nex
     })   
 });
 
+/***************** Search ***************************/
+
+/*
+* Find by all-matching list of transducer names.
+* HTTP GET query 'q' accepts comma delimited list, e.g. `/search/transducer?q=gps,temperature`
+*/
+router.get('/search/transducer', function(req, res, next){
+    if (!('q' in req.query)) { return res.json([]); }
+    transducerManager.getTransducerDevices(req.query.q, function(err, result){
+        if(err) { return next(err); }
+        return res.json(result);
+    })
+});
+
+
 /*************** Transducers ***************************/
 
 /* Add a transducer to device */
@@ -114,7 +129,6 @@ router.get('/:_id/transducer', function(req, res, next){
         return res.json(result);
     })
 });
-
 
 /* Register extra body parsers only for publishing transducer values */
 router.post('/:_id/transducer/:_transducerId', bodyParser.text(), bodyParser.raw());


### PR DESCRIPTION
New route `/device/search/transducer?q={query}` searches devices by transducer name(s).
(Optional: search query accepts comma-separated list to match-all).
Returns list of device id, name, transducers.