### PR TITLE
Add transducer update and unique name validation

### DIFF
--- a/src/middleware/resource_managers/transducer_manager.js
+++ b/src/middleware/resource_managers/transducer_manager.js
@@ -10,7 +10,6 @@ var SqlString = require('sqlstring');
 const redisOCDevicePrefix = nconf.get('redis_device_prefix');
 
 exports.createDeviceTransducer = function(req, callback ){
-
 	req.device.transducers.push(req.body);
 	req.device.save(callback);
 };
@@ -42,6 +41,26 @@ exports.getTransducerDevices = function(query, callback) {
         if (err) { return callback(err); }
         return callback(null, result);
     })
+};
+
+exports.updateTransducer = function(req, callback){
+    let deviceToUpdate = req.device;
+    let transducerToUpdate = {};
+    let transducerIndex = -1;
+
+    for (var i = 0; i < deviceToUpdate.transducers.length; i++) {
+        if (req.params._transducerId == deviceToUpdate.transducers[i].id) {
+            transducerToUpdate = deviceToUpdate.transducers[i];
+            transducerIndex = i;
+            break;
+        }
+    }
+
+    if(typeof req.body.name != 'undefined') transducerToUpdate.name = req.body.name;
+    if(typeof req.body.unit != 'undefined') transducerToUpdate.unit = req.body.unit;
+    if(typeof req.body.is_actuable != 'undefined') transducerToUpdate.is_actuable = req.body.is_actuable;
+    deviceToUpdate.transducers[transducerIndex] = transducerToUpdate;
+    deviceToUpdate.save(callback);
 };
 
 // Use redis to fetch the last value and timestamp for all transducers

--- a/src/models/device.js
+++ b/src/models/device.js
@@ -42,5 +42,20 @@ deviceSchema.index({ location_id : 1});
 deviceSchema.index({ name : "text" });
 deviceSchema.index({ "linked_services.service_id" :1 });
 
+// Note: any existing duplicates need to be manual cleaned out in mongoDB
+deviceSchema.pre('save', function(next){
+  let transducerNames = [];
+  for (var i = 0; i < this.transducers.length; i++) {
+    if (transducerNames.includes(this.transducers[i].name)) {
+        var error = new Error();
+        error.message = "Duplicate transducer name.";
+        return next(error);
+     } else {
+        transducerNames.push(this.transducers[i].name);
+     }
+  }
+  next();
+});
+
 // Return model
 module.exports = mongoose.model('Device', deviceSchema);

--- a/src/routes/device_router.js
+++ b/src/routes/device_router.js
@@ -148,6 +148,16 @@ router.get('/:_id/transducer', function(req, res, next){
     })
 });
 
+
+/* Update transducer  */
+router.put('/:_id/transducer/:_transducerId', deviceAuthorizer.checkWriteAccess,  function(req, res, next ){
+    transducerManager.updateTransducer(req, function(err, result){
+        if(err) { return next(err); }
+        return res.json(result);
+    })
+});
+
+
 /* Register extra body parsers only for publishing transducer values */
 router.post('/:_id/transducer/:_transducerId', bodyParser.text(), bodyParser.raw());
 


### PR DESCRIPTION
NOTE: Existing entries with duplicate entries must be manually
consolidated in mongoDB. Query to find dupes:
```
db.devices.aggregate([ {"$unwind":"$transducers"}, {"$group":
{"_id":{"_id":"$_id", "deviceName": "$name",
"tName":"$transducers.name"}, "count":{"$sum":1}}}, {"$match":
{"count":{"$gt":1}}} ])
```